### PR TITLE
[BUG-8288] Fix: Register custom JSON renderer to handle datetime serialization in API responses

### DIFF
--- a/pyramid_app_caseinterview/__init__.py
+++ b/pyramid_app_caseinterview/__init__.py
@@ -16,6 +16,7 @@ from pyramid_app_caseinterview.models import (
     get_session_factory,
     get_tm_session,
 )
+from pyramid_app_caseinterview.utils.custom_json_renderer import CustomJSONRenderer
 
 from .authorization import GlobalRootFactory, GlobalSecurityPolicy
 
@@ -186,6 +187,9 @@ def get_config(settings=None):
     config.include(".routes")
 
     config.scan()
+    # register a custom JSON renderer to handle serialization of non-standard objects
+    custom_json_renderer = CustomJSONRenderer()
+    config.add_renderer("json", custom_json_renderer)
     return config
 
 

--- a/pyramid_app_caseinterview/utils/custom_json_renderer.py
+++ b/pyramid_app_caseinterview/utils/custom_json_renderer.py
@@ -1,0 +1,16 @@
+"""Custom JSON Renderer to handle python objects serialization in Pyramid."""
+
+from pyramid.renderers import JSON
+from datetime import datetime
+
+
+class CustomJSONRenderer(JSON):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Add adapter to convert datetime to string format
+        self.add_adapter(datetime, self.datetime_adapter)
+
+    @staticmethod
+    def datetime_adapter(obj, request=None):
+        # Convert datetime to ISO 8601 format
+        return obj.isoformat()  #


### PR DESCRIPTION
##  Issue Identification
This issue arises because the default JSON renderer in the Pyramid framework does not handle datetime objects properly. In Python,` datetime` objects are not natively serializable to JSON.  JSON, as a data format, does not have a built-in way to represent complex objects like dates and times. When attempting to serialize `datetime` objects, Python will raise a TypeError, indicating that the object is not JSON serializable. This results in errors when such data is included in API responses.

## Possible Solution
Convert `datetime` objects to a format that can be used in JSON before returning the response. One way to do this is by using the `isoformat()` function, which changes `datetime` objects into ISO 8601 string format. This format is compatible with JSON, making it easier for other applications to process the data correctly.

## Design Solution
A custom JSON renderer is created with a method to convert `datetime` objects into ISO 8601 format. This renderer automatically handles the conversion whenever `datetime` objects are included in the response. This approach eliminates the need to manually apply the `isoformat()` method to each `datetime` value in the response, making the solution cleaner, more efficient, and reusable across the application.
    

