### PR TITLE
[BUG-8289] Fix: Ensure unique depth values in Depthseries API response by using DISTINCT in the query

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -36,7 +36,8 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        # Using DISTINCT on 'depth' to avoid duplicate entries in the Depthseries query
+        query = self.session.query(Depthseries).distinct(Depthseries.depth)
         return [
             {
                 "id": str(q.id),


### PR DESCRIPTION
##  Issue Identification
There is duplicate data in the database, and the query for the `depthseries` API retrieves all the data without any filtering.

## Possible Solution
To fix this issue, we can implement a filtering mechanism in the `depthseries` API query to remove duplicate entries. 

## Short-term Solution
In the short term, implementing the DISTINCT filter  on the` depthseries`  API query will resolve the immediate issue and provide users with a cleaner dataset.

## Long-term Solution
For a long-term fix, it is important to address the root cause of the duplicate data in the database. This can be achieved by implementing proper checks or constraints to prevent the insertion of duplicate depth values. One approach is to add a data validation step before the insert operation to verify whether the data already exists in the database. If duplicates are found, various approaches can be applied, such as skipping the duplicate data or implementing a defined data aggregation mechanism. Additionally, a unique constraint can be applied to the depth field at the database level to ensure that each depth value is unique.
    

