### PR TITLE
[BUG-8290] Fix: Add filter to remove records with null values in Depthseries API

### DIFF
--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -36,7 +36,8 @@ class API(View):
         request_method="GET",
     )
     def depthseries_api(self):
-        query = self.session.query(Depthseries)
+        # Query the Depthseries table to retrieve records where 'value' is not null
+        query = self.session.query(Depthseries).filter(Depthseries.value.isnot(None))
         return [
             {
                 "id": str(q.id),


### PR DESCRIPTION
##  Issue Identification
There is `depthseries` data with null value in the database, and the query for the `depthseries` API retrieves all the data without any filtering.

## Possible Solution
To fix this issue, we can implement a filtering mechanism in the `depthseries` API query to exclude data with null values. 

## Short-term Solution
In the short term, implementing the DISTINCT filter  on the `depthseries`  API query will resolve the immediate issue and provide users with a cleaner dataset.

## Long-term Solution
For a long-term fix, it's essential to prevent the insertion of records with null values in the value field. This can be achieved by adding a validation step before inserting data into the database to check if the value is null. Additionally, at the database level, we can set a NOT NULL constraint on the value field to ensure data integrity and prevent future issues.
    