### PR TITLE
[PBI-8291] Add: Implement date filtering for Timeseries API via query parameters

### DIFF
--- a/pyramid_app_caseinterview/__init__.py
+++ b/pyramid_app_caseinterview/__init__.py
@@ -16,6 +16,7 @@ from pyramid_app_caseinterview.models import (
     get_session_factory,
     get_tm_session,
 )
+from pyramid_app_caseinterview.utils.custom_json_renderer import CustomJSONRenderer
 
 from .authorization import GlobalRootFactory, GlobalSecurityPolicy
 
@@ -186,6 +187,9 @@ def get_config(settings=None):
     config.include(".routes")
 
     config.scan()
+    # register a custom JSON renderer to handle serialization of non-standard objects
+    custom_json_renderer = CustomJSONRenderer()
+    config.add_renderer("json", custom_json_renderer)
     return config
 
 

--- a/pyramid_app_caseinterview/utils/custom_json_renderer.py
+++ b/pyramid_app_caseinterview/utils/custom_json_renderer.py
@@ -1,0 +1,16 @@
+"""Custom JSON Renderer to handle python objects serialization in Pyramid."""
+
+from pyramid.renderers import JSON
+from datetime import datetime
+
+
+class CustomJSONRenderer(JSON):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Add adapter to convert datetime to string format
+        self.add_adapter(datetime, self.datetime_adapter)
+
+    @staticmethod
+    def datetime_adapter(obj, request=None):
+        # Convert datetime to ISO 8601 format
+        return obj.isoformat()  #

--- a/pyramid_app_caseinterview/utils/query_param_validator.py
+++ b/pyramid_app_caseinterview/utils/query_param_validator.py
@@ -1,0 +1,41 @@
+"""Class to validate query parameters in incoming requests"""
+
+from datetime import datetime
+from pyramid.httpexceptions import HTTPBadRequest
+
+
+class QueryParamValidator:
+
+    def __init__(self, request=None, **query_params):
+        self.request = request
+        self.invalid = []
+        self.validated = {}
+        self.query_params = query_params or {}
+
+    def validate_date_format(self, param_name):
+        """Validate if the date is in ISO format."""
+        date_str = self.request.GET.get(param_name)
+        try:
+            # If the date exists, attempt to parse it
+            self.validated[param_name] = (
+                datetime.fromisoformat(date_str) if date_str else None
+            )
+        except ValueError:
+            # If parsing fails, add an error message
+            self.invalid.append(
+                f"Invalid date format for {param_name}. Please use (YYYY-MM-DD) format."
+            )
+
+    def validate(self):
+        if self.query_params:
+            for key, rules in self.query_params.items():
+                for rule in rules.split(","):
+                    if rule == "date":
+                        self.validate_date_format(key)
+
+            if self.invalid:
+                raise HTTPBadRequest(
+                    f"Validation fields error: {' '.join(self.invalid)}"
+                )
+
+        return self.validated

--- a/pyramid_app_caseinterview/utils/utils.py
+++ b/pyramid_app_caseinterview/utils/utils.py
@@ -1,0 +1,18 @@
+"""Utility functions for project."""
+
+import difflib
+
+def list_all_routes(request):
+    """Retrieve all available routes from the request's registry."""
+    introspector = request.registry.introspector
+    routes = introspector.get_category("routes")
+    return [route["introspectable"]["pattern"] for route in routes]
+
+
+def find_closest_route(request):
+    """Find the closest matching route with a similarity threshold."""
+    requested_url = request.path_info
+    closest_matches = difflib.get_close_matches(
+        requested_url, list_all_routes(request), n=1, cutoff=0.8
+    )
+    return closest_matches[0] if closest_matches else None

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -45,3 +45,75 @@ class API(View):
             }
             for q in query.all()
         ]
+"""Sel value API"""
+
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.view import view_config
+
+from pyramid_app_caseinterview.models.depthseries import Depthseries
+from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.utils.query_param_validator import QueryParamValidator
+from pyramid.httpexceptions import HTTPBadRequest
+
+from . import View
+
+
+class API(View):
+    """API endpoints"""
+
+    @view_config(
+        route_name="timeseries",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer="json",
+        request_method="GET",
+    )
+    def timeseries_api(self):
+        # Initialize the query parameter validator for 'start_date' and 'end_date' with 'date' as the expected format
+        params = QueryParamValidator(
+            self.request, start_date="date", end_date="date"
+        ).validate()
+
+        # Ensure the start_date is not later than the end_date
+        if (
+            params["start_date"]
+            and params["end_date"]
+            and params["start_date"] > params["end_date"]
+        ):
+            raise HTTPBadRequest("start_date cannot be later than end_date")
+
+        # Start building the query for the Timeseries model
+        query = self.session.query(Timeseries)
+
+        # Apply the 'start_date' filter if provided
+        if params["start_date"]:
+            query = query.filter(Timeseries.datetime >= params["start_date"])
+            
+        # Apply the 'end_date' filter if provided
+        if params["end_date"]:
+            query = query.filter(Timeseries.datetime <= params["end_date"])
+
+        return [
+            {
+                "id": str(q.id),
+                "datetime": q.datetime,
+                "value": q.value,
+            }
+            for q in query.all()
+        ]
+
+    @view_config(
+        route_name="depthseries",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer="json",
+        request_method="GET",
+    )
+    def depthseries_api(self):
+        query = self.session.query(Depthseries)
+        return [
+            {
+                "id": str(q.id),
+                "depth": q.depth,
+                "value": q.value,
+            }
+            for q in query.all()
+        ]

--- a/pyramid_app_caseinterview/views/http_error_handler.py
+++ b/pyramid_app_caseinterview/views/http_error_handler.py
@@ -1,0 +1,83 @@
+"""HTTP Error Handlers."""
+
+import logging
+import traceback
+from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPNotFound, HTTPInternalServerError, HTTPBadRequest
+from pyramid_app_caseinterview.utils.utils import find_closest_route
+
+log = logging.getLogger(__name__)
+
+# Custom error handler for HTTP 404 (Not Found)
+@view_config(context=HTTPNotFound)
+def not_found_error(request):
+
+    # Find the closest route that might match the user's request
+    closest_route = find_closest_route(request)
+
+    # Prepare the error response message
+    message = message = f"The endpoint you requested could not be found. {'Did you mean ' + closest_route + '?' if closest_route else ''} Please check our documentation for more details."
+    response = {"status": "error", "message": message}
+        
+    # Return the response with status 404 (Not Found)
+    return Response(json_body=response, status=404)
+
+
+# Custom error handler for HTTP 500 (Internal Server Error)
+@view_config(context=HTTPInternalServerError)
+def internal_server_error(request):
+
+    # Log the real error message for debugging purposes
+    log.error("Internal Server Error")
+    log.error(traceback.format_exc())
+
+    response = {
+        "status": "error",
+        "message": "An unexpected error occurred on the server. Please try again later or contact support if the issue persists.",
+    }
+
+    # Return the response with status 500 (Internal Server Error)
+    return Response(
+        json_body=response,
+        status=500,
+    )
+
+
+# Custom error handler for HTTP 400 (Bad request)
+@view_config(context=HTTPBadRequest)
+def bad_request_error(request):
+
+    # Log the real error message for debugging purposes
+    error_message = str(request.exception)
+
+    response = {
+        "status": "error",
+        "message": f"One or more fields in the request failed validation. Please review and correct your input: {error_message}.",
+    }
+
+    # Return the response with status 400 (Bad Request)
+    return Response(
+        json_body=response,
+        status=400,
+    )
+
+
+# Custom error handler for general error exception
+@view_config(context=Exception)
+def general_error(request):
+
+    # Log the real error message for debugging purposes
+    log.error("General Error: An unexpected error occurred.")
+    log.error("Error details: %s", traceback.format_exc())
+
+    response = {
+        "status": "error",
+        "message": "An unexpected error occurred. Please try again later.",
+    }
+
+    # Return the response with status 500 (Internal Server Error)
+    return Response(
+        json_body=response,
+        status=500,
+    )

--- a/pyramid_app_caseinterview/views/notfound.py
+++ b/pyramid_app_caseinterview/views/notfound.py
@@ -3,7 +3,7 @@
 from pyramid.view import notfound_view_config
 
 
-@notfound_view_config(renderer="../templates/404.pug")
+#@notfound_view_config(renderer="../templates/404.pug")
 def notfound_view(request):
     """Show when the requested page could not be found."""
     request.response.status = 404


### PR DESCRIPTION
## Solution
### Handling Query Parameters 
To address the need for handling query parameters efficiently across different endpoints, I have designed the `QueryParamValidator` class. This class performs the following tasks:

1. **Parameter Existence Check**:  Ensures that the necessary query parameters are present in the request.


2. **Data Type Validation**: It validates that the query parameters match the expected data type, such as checking if the `start_date `and `end_date `parameters are in a valid date format.
3. **Error Handling**: If any validation fails, the class raises a 400 Bad Request error with a clear error message indicating which parameters are incorrect. the error message should like this 

>`{"status": "error","message": "One or more fields in the request failed validation. Please review and correct your input: Invalid date format for start_date. Please use (YYYY-MM-DD) format "}`

5. **Filter Application**: If validation is successful, the validated query parameters are returned and can be used directly in the database query to filter data accordingly.



### Filtering database query with validated query parameters
Once the query parameters are validated using the QueryParamValidator class, the next step is to apply these parameters in the database query for filtering.


If start_date is provided, the query filters records with a date greater than or equal to start_date.
If end_date is provided, the query filters records with a date less than or equal to end_date.

Example Scenario
Request with Only start_date:

> GET /api/v1/timeseries/?start_date=2025-01-01

The query will filter records from 2025-01-01 onwards.
Request with Only end_date:

> GET /api/v1/timeseries?end_date=2025-01-31

The query will filter records up to 2025-01-31
Request with Both start_date and end_date:

> GET /api/v1/timeseriesa?start_date=2025-01-01&end_date=2025-01-31

The query will filter records between 2025-01-01 and 2025-01-31


Invalid Date Range (start_date > end_date):

>GET /api/v1/timeseries?start_date=2025-01-31&end_date=2025-01-01

The query will return a 400 Bad Request with the error message:
>`{"status": "error","message": "One or more fields in the request failed validation. Please review and correct your input: start_date cannot be later than end_date "}`

This ensures that invalid queries are prevented, and the database is queried efficiently.

## Design Consideration

The QueryParamValidator class simplifies handling query parameters by validating their presence and data types, ensuring correct input before applying them in database queries. It improves efficiency by filtering out invalid queries and providing clear error messages. This reusable approach minimizes repetitive code across multiple endpoints, ensuring scalability and consistency in the API
