### PR TITLE
[PBI-8292] Test: Add tests for the Timeseries API endpoint

### DIFF
--- a/pyramid_app_caseinterview/__init__.py
+++ b/pyramid_app_caseinterview/__init__.py
@@ -16,6 +16,7 @@ from pyramid_app_caseinterview.models import (
     get_session_factory,
     get_tm_session,
 )
+from pyramid_app_caseinterview.utils.custom_json_renderer import CustomJSONRenderer
 
 from .authorization import GlobalRootFactory, GlobalSecurityPolicy
 
@@ -186,6 +187,9 @@ def get_config(settings=None):
     config.include(".routes")
 
     config.scan()
+    # register a custom JSON renderer to handle serialization of non-standard objects
+    custom_json_renderer = CustomJSONRenderer()
+    config.add_renderer("json", custom_json_renderer)
     return config
 
 

--- a/pyramid_app_caseinterview/utils/custom_json_renderer.py
+++ b/pyramid_app_caseinterview/utils/custom_json_renderer.py
@@ -1,0 +1,16 @@
+"""Custom JSON Renderer to handle python objects serialization in Pyramid."""
+
+from pyramid.renderers import JSON
+from datetime import datetime
+
+
+class CustomJSONRenderer(JSON):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Add adapter to convert datetime to string format
+        self.add_adapter(datetime, self.datetime_adapter)
+
+    @staticmethod
+    def datetime_adapter(obj, request=None):
+        # Convert datetime to ISO 8601 format
+        return obj.isoformat()  #

--- a/pyramid_app_caseinterview/utils/query_param_validator.py
+++ b/pyramid_app_caseinterview/utils/query_param_validator.py
@@ -1,0 +1,41 @@
+"""Class to validate query parameters in incoming requests"""
+
+from datetime import datetime
+from pyramid.httpexceptions import HTTPBadRequest
+
+
+class QueryParamValidator:
+
+    def __init__(self, request=None, **query_params):
+        self.request = request
+        self.invalid = []
+        self.validated = {}
+        self.query_params = query_params or {}
+
+    def validate_date_format(self, param_name):
+        """Validate if the date is in ISO format."""
+        date_str = self.request.GET.get(param_name)
+        try:
+            # If the date exists, attempt to parse it
+            self.validated[param_name] = (
+                datetime.fromisoformat(date_str) if date_str else None
+            )
+        except ValueError:
+            # If parsing fails, add an error message
+            self.invalid.append(
+                f"Invalid date format for {param_name}. Please use (YYYY-MM-DD) format."
+            )
+
+    def validate(self):
+        if self.query_params:
+            for key, rules in self.query_params.items():
+                for rule in rules.split(","):
+                    if rule == "date":
+                        self.validate_date_format(key)
+
+            if self.invalid:
+                raise HTTPBadRequest(
+                    f"Validation fields error: {' '.join(self.invalid)}"
+                )
+
+        return self.validated

--- a/pyramid_app_caseinterview/utils/query_param_validator.py
+++ b/pyramid_app_caseinterview/utils/query_param_validator.py
@@ -23,7 +23,7 @@ class QueryParamValidator:
         except ValueError:
             # If parsing fails, add an error message
             self.invalid.append(
-                f"Invalid date format for {param_name}. Please use (YYYY-MM-DD) format."
+                f"Invalid date format for {param_name}. Please use ISO 8601 (YYYY-MM-DD) or (YYYY-MM-DDTHH:MM:SS) format."
             )
 
     def validate(self):

--- a/pyramid_app_caseinterview/utils/utils.py
+++ b/pyramid_app_caseinterview/utils/utils.py
@@ -1,0 +1,18 @@
+"""Utility functions for project."""
+
+import difflib
+
+def list_all_routes(request):
+    """Retrieve all available routes from the request's registry."""
+    introspector = request.registry.introspector
+    routes = introspector.get_category("routes")
+    return [route["introspectable"]["pattern"] for route in routes]
+
+
+def find_closest_route(request):
+    """Find the closest matching route with a similarity threshold."""
+    requested_url = request.path_info
+    closest_matches = difflib.get_close_matches(
+        requested_url, list_all_routes(request), n=1, cutoff=0.8
+    )
+    return closest_matches[0] if closest_matches else None

--- a/pyramid_app_caseinterview/views/api.py
+++ b/pyramid_app_caseinterview/views/api.py
@@ -45,3 +45,75 @@ class API(View):
             }
             for q in query.all()
         ]
+"""Sel value API"""
+
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.view import view_config
+
+from pyramid_app_caseinterview.models.depthseries import Depthseries
+from pyramid_app_caseinterview.models.timeseries import Timeseries
+from pyramid_app_caseinterview.utils.query_param_validator import QueryParamValidator
+from pyramid.httpexceptions import HTTPBadRequest
+
+from . import View
+
+
+class API(View):
+    """API endpoints"""
+
+    @view_config(
+        route_name="timeseries",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer="json",
+        request_method="GET",
+    )
+    def timeseries_api(self):
+        # Initialize the query parameter validator for 'start_date' and 'end_date' with 'date' as the expected format
+        params = QueryParamValidator(
+            self.request, start_date="date", end_date="date"
+        ).validate()
+
+        # Ensure the start_date is not later than the end_date
+        if (
+            params["start_date"]
+            and params["end_date"]
+            and params["start_date"] > params["end_date"]
+        ):
+            raise HTTPBadRequest("start_date cannot be later than end_date")
+
+        # Start building the query for the Timeseries model
+        query = self.session.query(Timeseries)
+
+        # Apply the 'start_date' filter if provided
+        if params["start_date"]:
+            query = query.filter(Timeseries.datetime >= params["start_date"])
+            
+        # Apply the 'end_date' filter if provided
+        if params["end_date"]:
+            query = query.filter(Timeseries.datetime <= params["end_date"])
+
+        return [
+            {
+                "id": str(q.id),
+                "datetime": q.datetime,
+                "value": q.value,
+            }
+            for q in query.all()
+        ]
+
+    @view_config(
+        route_name="depthseries",
+        permission=NO_PERMISSION_REQUIRED,
+        renderer="json",
+        request_method="GET",
+    )
+    def depthseries_api(self):
+        query = self.session.query(Depthseries)
+        return [
+            {
+                "id": str(q.id),
+                "depth": q.depth,
+                "value": q.value,
+            }
+            for q in query.all()
+        ]

--- a/pyramid_app_caseinterview/views/http_error_handler.py
+++ b/pyramid_app_caseinterview/views/http_error_handler.py
@@ -1,0 +1,83 @@
+"""HTTP Error Handlers."""
+
+import logging
+import traceback
+from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPNotFound, HTTPInternalServerError, HTTPBadRequest
+from pyramid_app_caseinterview.utils.utils import find_closest_route
+
+log = logging.getLogger(__name__)
+
+# Custom error handler for HTTP 404 (Not Found)
+@view_config(context=HTTPNotFound)
+def not_found_error(request):
+
+    # Find the closest route that might match the user's request
+    closest_route = find_closest_route(request)
+
+    # Prepare the error response message
+    message = message = f"The endpoint you requested could not be found. {'Did you mean ' + closest_route + '?' if closest_route else ''} Please check our documentation for more details."
+    response = {"status": "error", "message": message}
+        
+    # Return the response with status 404 (Not Found)
+    return Response(json_body=response, status=404)
+
+
+# Custom error handler for HTTP 500 (Internal Server Error)
+@view_config(context=HTTPInternalServerError)
+def internal_server_error(request):
+
+    # Log the real error message for debugging purposes
+    log.error("Internal Server Error")
+    log.error(traceback.format_exc())
+
+    response = {
+        "status": "error",
+        "message": "An unexpected error occurred on the server. Please try again later or contact support if the issue persists.",
+    }
+
+    # Return the response with status 500 (Internal Server Error)
+    return Response(
+        json_body=response,
+        status=500,
+    )
+
+
+# Custom error handler for HTTP 400 (Bad request)
+@view_config(context=HTTPBadRequest)
+def bad_request_error(request):
+
+    # Log the real error message for debugging purposes
+    error_message = str(request.exception)
+
+    response = {
+        "status": "error",
+        "message": f"One or more fields in the request failed validation. Please review and correct your input: {error_message}.",
+    }
+
+    # Return the response with status 400 (Bad Request)
+    return Response(
+        json_body=response,
+        status=400,
+    )
+
+
+# Custom error handler for general error exception
+@view_config(context=Exception)
+def general_error(request):
+
+    # Log the real error message for debugging purposes
+    log.error("General Error: An unexpected error occurred.")
+    log.error("Error details: %s", traceback.format_exc())
+
+    response = {
+        "status": "error",
+        "message": "An unexpected error occurred. Please try again later.",
+    }
+
+    # Return the response with status 500 (Internal Server Error)
+    return Response(
+        json_body=response,
+        status=500,
+    )

--- a/pyramid_app_caseinterview/views/notfound.py
+++ b/pyramid_app_caseinterview/views/notfound.py
@@ -3,7 +3,7 @@
 from pyramid.view import notfound_view_config
 
 
-@notfound_view_config(renderer="../templates/404.pug")
+#@notfound_view_config(renderer="../templates/404.pug")
 def notfound_view(request):
     """Show when the requested page could not be found."""
     request.response.status = 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,3 +64,21 @@ def session_tm_module_scope(app):
     session = get_tm_session(session_factory, transaction.manager)
     yield session
     session.close()
+
+
+@pytest.fixture(scope="module")
+def seed_time_series_data(session):
+    """Generate and insert random data into the Timeseries table."""
+    from faker import Faker
+    from pyramid_app_caseinterview.models.timeseries import Timeseries
+
+    fake = Faker()
+    records = []
+    for _ in range(100):
+        datetime_value = fake.date_time_this_century()
+        value = fake.random_number(digits=3)
+        records.append(Timeseries(datetime=datetime_value, value=value))
+
+    session.bulk_save_objects(records)
+    session.commit()
+ 

--- a/tests/test_timeseries_api.py
+++ b/tests/test_timeseries_api.py
@@ -1,0 +1,192 @@
+"""Class for testing Timeseries API"""
+
+from datetime import date, datetime
+from faker import Faker
+
+
+class TestTimeseriesAPI:
+    def test_success_fetch_timeseries_data(
+        self, testapp, seed_time_series_data
+    ) -> None:
+        res = testapp.get("/api/v1/timeseries", status=200)
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert isinstance(json_data, list), "Response should be a list"
+
+    def test_response_schema_validation(self, testapp) -> None:
+        res = testapp.get("/api/v1/timeseries", status=200)
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        for item in json_data:
+            assert all(
+                key in item for key in ["datetime", "value"]
+            ), "Each item should contain 'datetime' and 'value'"
+
+    def test_notfound_response_on_unexist_timeseries_endpoint(self, testapp) -> None:
+        res = testapp.get("/api/v1/timeserie", status=404)
+
+        assert (
+            res.status_code == 404
+        ), f"Expected status code 404 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+        assert json_data.get("status") == "error", "Status should be 'error'"
+        assert "message" in json_data, "Error message should be provided"
+
+    def test_success_fetch_filtered_timeseries_data_with_start_date_only(
+        self, testapp
+    ) -> None:
+        fake = Faker()
+        random_date = fake.date_time_between_dates(date(2000, 1, 1), date(2024, 12, 31))
+        res = testapp.get(f"/api/v1/timeseries?start_date={random_date}", status=200)
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+        assert isinstance(json_data, list), "Response should be a list"
+        assert all(
+            datetime.fromisoformat(item["datetime"]) >= random_date
+            for item in json_data
+        ), f"Response contains data before {random_date}"
+
+    def test_success_fetch_filtered_timeseries_data_with_end_date_only(
+        self, testapp
+    ) -> None:
+        fake = Faker()
+        random_date = fake.date_time_between_dates(date(2000, 1, 1), date(2024, 12, 31))
+        res = testapp.get(f"/api/v1/timeseries?end_date={random_date}", status=200)
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert isinstance(json_data, list), "Response should be a list"
+        assert all(
+            datetime.fromisoformat(item["datetime"]) <= random_date
+            for item in json_data
+        ), f"Response contains data after {random_date}"
+
+    def test_success_fetch_filtered_timeseries_data_between_start_date_and_end_date(
+        self, testapp
+    ) -> None:
+
+        fake = Faker()
+
+        random_start_date = fake.date_time_between_dates(
+            date(2000, 1, 1), date(2011, 12, 31)
+        )
+        random_end_date = fake.date_time_between_dates(
+            date(2015, 1, 1), date(2024, 12, 31)
+        )
+
+        res = testapp.get(
+            f"/api/v1/timeseries?start_date={random_start_date}&end_date={random_end_date}",
+            status=200,
+        )
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert isinstance(json_data, list), "Response should be a list"
+        assert all(
+            random_start_date
+            <= datetime.fromisoformat(item["datetime"])
+            <= random_end_date
+            for item in json_data
+        ), f"Response contains data outside the range {random_start_date} - {random_end_date}"
+
+    def test_fail_when_try_fetch_filtered_timeseries_data_with_wrong_format_date(
+        self, testapp
+    ) -> None:
+
+        res = testapp.get(
+            "/api/v1/timeseries?start_date=2002-03-0d&end_date=wrong", status=400
+        )
+
+        assert res.status_code == 400, f"Expected status 400 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert json_data.get("status") == "error", "Status should be 'error'"
+        assert "message" in json_data, "Error message should be provided"
+
+    def test_fail_when_start_date_is_later_than_end_date(self, testapp) -> None:
+        fake = Faker()
+
+        random_start_date = fake.date_between_dates(
+            date(2015, 1, 1), date(2024, 12, 31)
+        )
+        random_end_date = fake.date_between_dates(date(2000, 1, 1), date(2014, 12, 31))
+
+        res = testapp.get(
+            f"/api/v1/timeseries?start_date={random_start_date}&end_date={random_end_date}",
+            status=400,
+        )
+
+        assert (
+            res.status_code == 400
+        ), f"Expected status code 400 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert json_data.get("status") == "error", "Status should be 'error'"
+        assert "message" in json_data, "Error message should be provided"
+
+    def test_empty_response_for_non_matching_filter(self, testapp) -> None:
+
+        res = testapp.get(
+            "/api/v1/timeseries?start_date=3000-01-01&end_date=3000-12-31", status=200
+        )
+
+        assert (
+            res.status_code == 200
+        ), f"Expected status code 200 but got {res.status_code}"
+        assert (
+            res.content_type == "application/json"
+        ), "Response content type is not JSON"
+
+        json_data = res.json
+
+        assert isinstance(json_data, list), "Response should be a list"
+        assert len(json_data) == 0, "Response should be empty for non-matching filters"


### PR DESCRIPTION
## Solution

Using pytest and webtest for testing, which includes several scenarios that were previously covered in the `BUG#8287`, `BUG#8788`, and `PBI#8291` tickets. The scenarios are as follows:

**1. Testing Timeseries API Response (Successful Response)**
In this first test, a seeder is included to populate data for testing purposes. This test ensures that the API returns a valid response with data, and that the data is returned in the expected format.
The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Is the response an object list?
> Testing Timeseries API Response (Successful Response)


**2. Testing Timeseries API Response Schema**
The purpose of this test is to check if the structure of the timeseries object in the response is correct. 
The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Does each object in the response list have datetime and value fields?


**3.Testing Notfound Response**
This test checks the response when accessing a non-existent URL, ensuring the expected JSON response is returned. 
The following parameters are checked:

> Is the response status 404?
> Is the response in JSON format?
> Does the response contain the fields message and status?


**4. Testing Timeseries Filter with start_date Query Parameter Only**
This test ensures that the API correctly filters data based on the start date and returns only relevant data.
 The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Is the response an object list?
> Does the response contain no data earlier than the start_date?


**5. Testing Timeseries Filter with end_date Query Parameter Only**
This test ensures that the API correctly filters data based on the end_date and returns only relevant data.
 The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Is the response an object list?
> Does the response contain no data later than the end_date?

**6. Testing Timeseries Filter with start_date and end_date Query Parameters**
This test checks if filtering with both start_date and end_date works correctly. The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Is the response an object list?
> Does the response contain no data earlier than the start_date and no data later than the end_date?

**7. Testing Timeseries Filter with Invalid start_date and end_date Formats**
This test checks if validation works when using incorrect date formats for start_date and end_date. The following parameters are checked:

> Is the response status 400?
> Is the response in JSON format?
> Does the response contain the status field with the value "error"?
> Does the response contain the message field?

**8. Testing Timeseries Filter with start_date Greater Than end_date**
This test checks if validation works when start_date is later than end_date. The following parameters are checked:

> Is the response status 400?
> Is the response in JSON format?
> Does the response contain the status field with the value "error"?
> Does the response contain the message field?

**9. Testing Timeseries Filter with start_date and end_date That Produce No Data**
This test checks if filtering with a date range that doesn’t exist in the database results in an empty list. The following parameters are checked:

> Is the response status 200?
> Is the response in JSON format?
> Is the response a list?
> Is the JSON list empty?